### PR TITLE
Update to 1.15 . Use "/usr/bin/env perl" in shebangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search automake --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Fix shebangs
+for f in bin/aclocal.in bin/automake.in t/wrap/aclocal.in t/wrap/automake.in; do
+    sed -i.bak -e 's|^#!@PERL@ -w|#!/usr/bin/env perl|' "$f"
+    rm -f "$f.bak"
+done
+
 ./configure --prefix=$PREFIX
 make
 # make check TODO: There is one failure I need to check.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14" %}
+{% set version = "1.15" %}
 
 package:
     name: automake
@@ -7,10 +7,10 @@ package:
 source:
     fn: automake-{{ version }}.tar.gz
     url: http://ftp.gnu.org/gnu/automake/automake-{{ version }}.tar.gz
-    sha256: 7847424d4204d1627c129e9c15b81e145836afa2a1bf9003ffe10aa26ea75755
+    sha256: 7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
 
 build:
-    number: 2
+    number: 0
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
`/usr/bin/perl` is replaced by Conda with the path of the perl installed in
the Conda env, which can be quite long. This easily breaks because there is
a limit on the length of the shebang.